### PR TITLE
Added fix for to_python() being json.dumped() twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 7/29/2019 1.3.16
+Fixed `SimplifyJsonTextField` custom Django field to prevent json.dumping() value more than once
+
 ### 7/29/2019 1.3.14
 Added `SimplifyJsonTextField` custom Django field which allows a non-json compatible database to handle json responsibly
 

--- a/rest_framework_simplify/fields.py
+++ b/rest_framework_simplify/fields.py
@@ -93,6 +93,10 @@ class SimplifyEncryptedCharField(SimplifyEncryptedField):
 
 class SimplifyJsonTextField(models.TextField):
 
+    class ErrorMessages:
+        INVALID_DB_VALUE = 'Invalid db value for SimplifyJsonTextField instance: {0}'
+        INVALID_PYTHON_VALUE = 'Invalid python value for SimplifyJsonTextField instance: {0}'
+
     def __init__(self, *args, **kwargs):
         super(models.TextField, self).__init__(*args, **kwargs)
 
@@ -103,12 +107,13 @@ class SimplifyJsonTextField(models.TextField):
         try:
             new_value = json.loads(value)
         except Exception as e:
-            raise ValidationError("Invalid db value for SimplifyJsonTextField instance")
+            raise ValidationError(SimplifyJsonTextField.ErrorMessages.INVALID_DB_VALUE
+                                  .format(str(value)))
 
         return new_value
 
     def to_python(self, value):
-        if isinstance(value, SimplifyJsonTextField):
+        if isinstance(value, str):
             return value
 
         if value is None:
@@ -117,6 +122,7 @@ class SimplifyJsonTextField(models.TextField):
         try:
             new_value = json.dumps(value)
         except Exception as e:
-            raise ValidationError("Invalid python value for SimplifyJsonTextField instance")
+            raise ValidationError(SimplifyJsonTextField.ErrorMessages.INVALID_PYTHON_VALUE
+                                  .format(str(value)))
 
         return new_value

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='django-rest-framework-simplify',
-    version='1.3.14.dev1',
+    version='1.3.16.dev1',
     description='Django Rest Framework Simplify',
     author='Skyler Cain',
     author_email='skylercain@gmail.com',

--- a/test_app/tests/test_fields.py
+++ b/test_app/tests/test_fields.py
@@ -96,6 +96,22 @@ class CustomFieldTests(unittest.TestCase):
             self.assertIsNotNone(jt_return)
             self.assertTrue(isinstance(jt_return.json_text, List))
 
+        def test_json_text_field_returns_json_value_as_list_when_to_python_called_twice(self):
+            # arrange
+            json_text = [{ "description": "isn\'t it beautiful outside?" }]
+            jt_class = DataGenerator.set_up_json_text_field_class(
+                json_text=json_text)
+
+            jt_class.json_text = json.dumps(json_text)
+            jt_class.save()
+
+            # act
+            jt_return = JsonTextFieldClass.objects.get(id=jt_class.id)
+
+            # assert
+            self.assertIsNotNone(jt_return)
+            self.assertTrue(isinstance(jt_return.json_text, List))
+
         def test_json_text_field_returns_json_value_as_object(self):
             # arrange
             json_text = json.loads('{ "description": "isn\'t it beautiful outside?" }')
@@ -129,8 +145,8 @@ class CustomFieldTests(unittest.TestCase):
             jt_class = DataGenerator.set_up_json_text_field_class(
                 json_text=json_text_in_db)
 
-            jt_return = JsonTextFieldClass.objects.get(id=jt_class.id)
-
-            # assert
-            self.assertIsNotNone(jt_return.json_text)
-            self.assertTrue(isinstance(jt_return.json_text, str))
+            # act / assert
+            with self.assertRaises(ValidationError) as ex:
+                jt_return = JsonTextFieldClass.objects.get(id=jt_class.id)
+            self.assertEqual(ex.exception.args[0], SimplifyJsonTextField.
+                             ErrorMessages.INVALID_DB_VALUE.format(json_text_in_db))

--- a/test_app/tests/test_fields.py
+++ b/test_app/tests/test_fields.py
@@ -137,7 +137,7 @@ class CustomFieldTests(unittest.TestCase):
             # assert
             self.assertIsNone(jt_return.json_text)
 
-        def test_json_text_field_returns_string_when_json_in_database_is_malformed(self):
+        def test_json_text_field_throws_error_when_json_in_database_is_malformed(self):
             # arrange
             json_text_in_db = '[{ \'description\':: \'isn\'t it beautiful outside?\' }]'
 


### PR DESCRIPTION
Beforehand it was json.dumping() the value twice, which resulted in it not json.loading() the value correctly into a non-string all the time. Plus, now that I fixed the `to_python` values, the errors are working more as I expected they would initially and therefore I also enhanced the ErrorMessages as well w/tests around all of it. 

Sorry about that, I probably should have caught that beforehand, but now at least I have tests simulating that exact scenario which are now passing. No need to worry about what was already released because this field wasn't used anywhere before now. I'll send you a video demonstrating the final walk-through in rd-api so that you can see where it was going wrong beforehand. The main fix here is just in the `to_python` method, instead of doing `if isinstance(value, SimplifyJsonTextField):` I now do `if isinstance(value, str):`, which prevents it from dual or triple `json.dumping()` the value which makes it so the `from_db_value()` will now always result in a non-string value or else it will fail. (Hence the enhanced error_messages now)