### PR TITLE
add links query param to post, allowing for adding extra linker entri…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='django-rest-framework-simplify',
-    version='1.3.24.dev1',
+    version='1.3.25.dev1',
     description='Django Rest Framework Simplify',
     author='Skyler Cain',
     author_email='skylercain@gmail.com',

--- a/test_app/tests/test_views.py
+++ b/test_app/tests/test_views.py
@@ -233,6 +233,21 @@ class BasicClassTests(unittest.TestCase):
         linking_classes = LinkingClass.objects.filter(basic_class=basic_class)
         self.assertEqual(len(linking_classes), 1)
 
+    def test_post_with_links_param(self):
+        # arrange
+        child_class = DataGenerator.set_up_child_class()
+        url = '/basicClass?links=linking_classes__child_class_id={}'.format(child_class.id)
+        body = {
+            'name': 'test 123'
+        }
+
+        # act
+        result = self.api_client.post(url, body, format='json')
+
+        # assert
+        child_class.refresh_from_db()
+        self.assertEqual(LinkingClass.objects.filter(child_class_id=child_class.id, basic_class_id=result.data['id']).count(), 1)
+
     def test_post_sub_resource_to_linking_class_with_id(self):
         # arrange
         basic_class = DataGenerator.set_up_basic_class()


### PR DESCRIPTION
…es after post

there are scenarios (the contact table for us at RD) where we need to add a linker entry in addition to one that can be done with a post sub. This allows for one request post to have as many linkers as needed, which will help us avoid writing custom endpoints or exposing linker tables in the api.

I've added you all to see if this is something that you are okay with.