### PR TITLE
Fix type passed to obj permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,45 +266,6 @@ Now we can:
 Simplify provides a variety of methods for customizing permissions that are heavily inspired by
 [Rest Framework permissions](https://www.django-rest-framework.org/api-guide/permissions/).
 
-### Permission class support
-
-Permission classes work as you would expect in Rest Framework. A default permission class may be
-specified per Rest Framework's guidelines, otherwise the `AllowAny` permission class will be used.
-Another option is to specify permission classes at the view level. This can be accomplished with the
-`permission_classes` attribute or the `permission_classes` decorator if you are using function based
-views. Custom permission classes are implemented by extending BasePermission which consists of two
-methods `has_permission` and `has_object_permission`.
-
-As advertised in Rest Framework's documentation, permission classes may be composed using bitwise
-operators. `&` (and), `|` (or), and `~` (not). For example, `permissions_classes = [Super & ~Evil]`
-a super user who is not evil.
-
-`has_permission` is invoked before each handler (`get`, `put`, `post`, `delete`) and is intended to
-resolve permissions pertaining to the model type rather than an instance of the model. Such as the
-user's permission to read/write all instances of `FooModel` based on their user role.
-
-`has_object_permission` is for resolving "row" level permissions. For example, the user may only
-edit objects related to the user. `has_object_permission` is invoked when the desired instance is
-fetched. Note `has_object_permission` is not invoked for a list view due to performance reasons or a
-post because there is no instance. This behavior translates to Rest Framework's way of doing things.
-
-Example:
-```python
-class BasicPermission(BasePermission):
-    def has_permission(self, request, view):
-        return True
-
-    def has_object_permission(self, request, view, obj):
-        return True
-
-
-class FooHandler(SimplifyView):
-    permission_classes = [BasicPermission]
-
-    def __init__(self):
-        super().__init__(FooModel, supported_methods=['GET'])
-```
-
 ### Queryset permission support
 
 Permission support for a list view is facilitated by `get_queryset` whose implementation is
@@ -405,4 +366,46 @@ class FooEmailTemplate(EmailTemplateForm):
             raise ValidationError('you gotta be super')
         self.cleaned_data['from'] = self.request.user.email
         return self.super().clean()
+```
+
+### Permission class support
+
+> [!CAUTION]
+> Permission classes making use of `has_object_permission` are partially implemented and should not be relied on.
+
+Permission classes work as you would expect in Rest Framework. A default permission class may be
+specified per Rest Framework's guidelines, otherwise the `AllowAny` permission class will be used.
+Another option is to specify permission classes at the view level. This can be accomplished with the
+`permission_classes` attribute or the `permission_classes` decorator if you are using function based
+views. Custom permission classes are implemented by extending BasePermission which consists of two
+methods `has_permission` and `has_object_permission`.
+
+As advertised in Rest Framework's documentation, permission classes may be composed using bitwise
+operators. `&` (and), `|` (or), and `~` (not). For example, `permissions_classes = [Super & ~Evil]`
+a super user who is not evil.
+
+`has_permission` is invoked before each handler (`get`, `put`, `post`, `delete`) and is intended to
+resolve permissions pertaining to the model type rather than an instance of the model. Such as the
+user's permission to read/write all instances of `FooModel` based on their user role.
+
+`has_object_permission` is for resolving "row" level permissions. For example, the user may only
+edit objects related to the user. `has_object_permission` is invoked when the desired instance is
+fetched. Note `has_object_permission` is not invoked for a list view due to performance reasons or a
+post because there is no instance. This behavior translates to Rest Framework's way of doing things.
+
+Example:
+```python
+class BasicPermission(BasePermission):
+    def has_permission(self, request, view):
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        return True
+
+
+class FooHandler(SimplifyView):
+    permission_classes = [BasicPermission]
+
+    def __init__(self):
+        super().__init__(FooModel, supported_methods=['GET'])
 ```

--- a/rest_framework_simplify/views.py
+++ b/rest_framework_simplify/views.py
@@ -120,7 +120,6 @@ class SimplifyView(APIView):
                 obj = self.get_queryset().using(self.read_db).filter(pk=pk)
                 is_single_result = True
                 empty_is_error = True
-            self.check_object_permissions(request, obj)
 
         else:
             # we could be a sub resource so we need to check if a parent_resource was passed in
@@ -467,6 +466,9 @@ class SimplifyView(APIView):
                     body = {}
                 elif len(body) == 1:
                     body = body[0]
+                    # TODO must make this check in order for permission classes to work with objects
+                    # see pull request #59 for details.
+                    # self.check_object_permissions(request, obj.first())
                 else:
                     raise Exception('duplicate object for key')
 
@@ -483,6 +485,7 @@ class SimplifyView(APIView):
                     body = {}
                 elif len(body) == 1:
                     body = body[0]
+                    self.check_object_permissions(request, body)
                 else:
                     raise Exception('duplicate object for key')
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='django-rest-framework-simplify',
-    version='4.0.1.dev1',
+    version='4.0.2.dev1',
     description='Django Rest Framework Simplify',
     author='Skyler Cain',
     author_email='skylercain@gmail.com',


### PR DESCRIPTION
The issue being addressed here is we were passing a queryset instead of a model instance to the permission class. This is only a partially implemented feature at this point.

This is because another issue was revealed in that the fields query param conflicts with the idea of the permission class interface. This could likely be resolved by pushing the fields logic into the `create_response` like we do in other paths. Or by refetching the object as shown in the TODO comment.

Either way has tradeoffs by introducing a needless database query or lowering the selectivity of the query and I'm not sure this feature is even necessary. The optimal solution could be removing object level permissions since the `get_queryset` method solves the problem. In the meantime I propose we leave the half implemented solution.