### PR TITLE
Exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ CACHES = {
 }
 ```
 
+To use the [Simplify exception handler](#exceptions) you must define it in the REST_FRAMEWORK settings:
+```python
+REST_FRAMEWORK = {
+  'EXCEPTION_HANDLER': 'rest_framework_simplify.handler.exception_handler'
+}
+```
+The logger named `rest-framework-simplify-exception` must be configured to see the logs.
+
 
 ## Models
 Django Rest Framework Simplify provides a `SimplifyModel` class, which subclasses Django's `DjangoModel` class. The `SimplifyModel` allows you to have additional properties on your model, for example:
@@ -409,3 +417,34 @@ class FooHandler(SimplifyView):
     def __init__(self):
         super().__init__(FooModel, supported_methods=['GET'])
 ```
+
+## Exceptions
+
+See the [Settings](#settings) section for information on configuring the custom exception handler.
+
+The Simplify exception handler aims to log detailed exceptions and return vague error messages to
+consumers. This decision was made for security reasons.
+
+Rest Framework's exceptions that extend APIException will propagate their status_code and
+default_detail to the JSON response.
+
+In order to raise a custom exception that will propagate to the JSON response you must extend Rest
+Framework's APIException like so:
+```python
+from rest_framework.exceptions import APIException
+
+
+class FooException(APIException):
+    status_code = 418
+    default_detail = 'Foo message.'
+```
+
+These JSON responses are of a consistent format like the following:
+```json
+{
+  "errorMessage": "Foo message."
+}
+```
+
+Additionally, the Simplify error handler converts Django exceptions to Rest Framework's equivalents
+like the default Rest Framework exception handler.

--- a/rest_framework_simplify/exceptions.py
+++ b/rest_framework_simplify/exceptions.py
@@ -1,3 +1,8 @@
+from typing import Optional
+
+from rest_framework.exceptions import APIException
+
+
 class ParseException(Exception):
     def __init__(self, ex):
         # Call the base class constructor with the parameters it needs
@@ -12,3 +17,22 @@ class EmailTemplateException(Exception):
     def __init__(self, message):
         # Call the base class constructor with the parameters it needs
         super(EmailTemplateException, self).__init__(message)
+
+
+class SimplifyAPIException(APIException):
+    """
+    SimplifyAPIException is an APIException that assigns the provided error_message to the
+    default_detail. This is intended to work with the Simplify exception_handler since the handler
+    returns uses default_detail instead of detail.
+    """
+
+    def __init__(self, error_message: Optional[str] = None, status_code: Optional[int] = None):
+        """
+        :param str error_message: error message to show in the response
+        :param int status_code: status code associated with the response
+        """
+        if error_message is not None:
+            self.default_detail = error_message
+        if status_code is not None:
+            self.status_code = status_code
+        super().__init__()

--- a/rest_framework_simplify/handler.py
+++ b/rest_framework_simplify/handler.py
@@ -45,7 +45,7 @@ def exception_handler(exc: Exception, context: _Context) -> Response:
     )
 
 
-def _django_to_rest_framework(exc):
+def _django_to_rest_framework(exc: Exception):
     if isinstance(exc, Http404):
         return exceptions.NotFound()
     if isinstance(exc, PermissionDenied):

--- a/rest_framework_simplify/handler.py
+++ b/rest_framework_simplify/handler.py
@@ -1,0 +1,51 @@
+import logging
+import traceback
+from typing import TypedDict
+
+from rest_framework import status
+from rest_framework.exceptions import APIException, NotAuthenticated, AuthenticationFailed
+from rest_framework.response import Response
+from rest_framework.request import Request
+
+
+class _Context(TypedDict):
+    request: Request
+
+
+def exception_handler(exc: Exception, context: _Context) -> Response:
+    status_code = status.HTTP_400_BAD_REQUEST
+    error_message = APIException.default_detail
+
+    if isinstance(exc, (NotAuthenticated, AuthenticationFailed)):
+        status_code = status.HTTP_403_FORBIDDEN
+
+    if exc.args:
+        error_message = exc.args[0]
+
+    # only want the last frame in generator
+    exc_filename = None
+    exc_lineno = None
+    exc_func = None
+    for frame, lineno in traceback.walk_tb(exc.__traceback__):
+        exc_filename = frame.f_code.co_filename
+        exc_lineno = lineno
+        exc_func = frame.f_code.co_name
+
+    logger = logging.getLogger('rest-framework-simplify-exception')
+    extra = {
+        'rq_query_params': context['request'].query_params.dict(),
+        'rq_data': context['request'].data,
+        'rq_method': context['request'].method,
+        'rq_path': context['request'].path,
+        'rs_status_code': status_code,
+        'exc_filename': exc_filename,
+        'exc_lineno': exc_lineno,
+        'exc_func': exc_func
+    }
+    logger.error(error_message, extra=extra)
+
+    return Response(
+        { 'errorMessage': error_message },
+        status=status_code,
+        content_type='application/json'
+    )

--- a/rest_framework_simplify/handler.py
+++ b/rest_framework_simplify/handler.py
@@ -2,8 +2,9 @@ import logging
 import traceback
 from typing import TypedDict
 
-from rest_framework import status
-from rest_framework.exceptions import APIException, NotAuthenticated, AuthenticationFailed
+from django.http import Http404
+from django.core.exceptions import PermissionDenied
+from rest_framework import exceptions, status
 from rest_framework.response import Response
 from rest_framework.request import Request
 
@@ -13,39 +14,63 @@ class _Context(TypedDict):
 
 
 def exception_handler(exc: Exception, context: _Context) -> Response:
+    """
+    exception_handler logs detailed exceptions and returns generic messages to consumers. The
+    messages are vague for security reasons.
+
+    Exceptions extending APIException are able to pass through messages with the default_detail
+    field and status codes with the status_code field.
+
+    Django's Http404 and PermissionDenied are translated to Rest Framework's NotFound and
+    PermissionDenied.
+
+    NotAuthenticated and AuthenticationFailed are coerced to a 403 status.
+    """
+    # Historically, 400 has been the default instead of 500.
     status_code = status.HTTP_400_BAD_REQUEST
-    error_message = APIException.default_detail
+    error_message = exceptions.APIException.default_detail
 
-    if isinstance(exc, (NotAuthenticated, AuthenticationFailed)):
-        status_code = status.HTTP_403_FORBIDDEN
+    exc = _django_to_rest_framework(exc)
 
-    if exc.args:
-        error_message = exc.args[0]
+    if isinstance(exc, exceptions.APIException):
+        status_code = exc.status_code
+        # default_detail is chosen over detail in order to not expose too much information.
+        error_message = exc.default_detail
 
-    # only want the last frame in generator
-    exc_filename = None
-    exc_lineno = None
-    exc_func = None
-    for frame, lineno in traceback.walk_tb(exc.__traceback__):
-        exc_filename = frame.f_code.co_filename
-        exc_lineno = lineno
-        exc_func = frame.f_code.co_name
-
-    logger = logging.getLogger('rest-framework-simplify-exception')
-    extra = {
-        'rq_query_params': context['request'].query_params.dict(),
-        'rq_data': context['request'].data,
-        'rq_method': context['request'].method,
-        'rq_path': context['request'].path,
-        'rs_status_code': status_code,
-        'exc_filename': exc_filename,
-        'exc_lineno': exc_lineno,
-        'exc_func': exc_func
-    }
-    logger.error(error_message, extra=extra)
+    _log_exception(exc, context, status_code, error_message)
 
     return Response(
         { 'errorMessage': error_message },
         status=status_code,
         content_type='application/json'
     )
+
+
+def _django_to_rest_framework(exc):
+    if isinstance(exc, Http404):
+        return exceptions.NotFound()
+    if isinstance(exc, PermissionDenied):
+        return exceptions.PermissionDenied()
+    return exc
+
+
+def _log_exception(exc: Exception, context: _Context, status_code: int, error_message):
+    last_frame, last_lineno = list(traceback.walk_tb(exc.__traceback__))[-1]
+    exc_filename = last_frame.f_code.co_filename
+    exc_lineno = last_lineno
+    exc_func = last_frame.f_code.co_name
+
+    logger = logging.getLogger('rest-framework-simplify-exception')
+    extra = {
+        'rq_query_params': context['request'].query_params,
+        'rq_data': context['request'].data,
+        'rq_method': context['request'].method,
+        'rq_path': context['request'].path,
+        'rs_status_code': status_code,
+        'exc_filename': exc_filename,
+        'exc_lineno': exc_lineno,
+        'exc_func': exc_func,
+        'exc_first_arg': exc.args[0] if exc.args else None,
+        'exc_detail': exc.detail if isinstance(exc, exceptions.APIException) else None
+    }
+    logger.exception(error_message, extra=extra)

--- a/rest_framework_simplify/handler.py
+++ b/rest_framework_simplify/handler.py
@@ -54,7 +54,7 @@ def _django_to_rest_framework(exc):
     return exc
 
 
-def _log_exception(exc: Exception, context: _Context, status_code: int, error_message):
+def _log_exception(exc: Exception, context: _Context, status_code: int, error_message: str):
     last_frame, last_lineno = list(traceback.walk_tb(exc.__traceback__))[-1]
     exc_filename = last_frame.f_code.co_filename
     exc_lineno = last_lineno

--- a/rest_framework_simplify/handler.py
+++ b/rest_framework_simplify/handler.py
@@ -38,18 +38,14 @@ def exception_handler(exc: Exception, context: _Context) -> Response:
 
     _log_exception(exc, context, status_code, error_message)
 
-    return Response(
-        { 'errorMessage': error_message },
-        status=status_code,
-        content_type='application/json'
-    )
+    return Response({ 'errorMessage': error_message }, status=status_code)
 
 
 def _django_to_rest_framework(exc: Exception):
     if isinstance(exc, Http404):
-        return exceptions.NotFound()
+        return exceptions.NotFound(*exc.args)
     if isinstance(exc, PermissionDenied):
-        return exceptions.PermissionDenied()
+        return exceptions.PermissionDenied(*exc.args)
     return exc
 
 

--- a/rest_framework_simplify/handler.py
+++ b/rest_framework_simplify/handler.py
@@ -1,5 +1,4 @@
 import logging
-import traceback
 from typing import TypedDict
 
 from django.http import Http404
@@ -55,11 +54,6 @@ def _django_to_rest_framework(exc):
 
 
 def _log_exception(exc: Exception, context: _Context, status_code: int, error_message: str):
-    last_frame, last_lineno = list(traceback.walk_tb(exc.__traceback__))[-1]
-    exc_filename = last_frame.f_code.co_filename
-    exc_lineno = last_lineno
-    exc_func = last_frame.f_code.co_name
-
     logger = logging.getLogger('rest-framework-simplify-exception')
     extra = {
         'rq_query_params': context['request'].query_params,
@@ -67,9 +61,6 @@ def _log_exception(exc: Exception, context: _Context, status_code: int, error_me
         'rq_method': context['request'].method,
         'rq_path': context['request'].path,
         'rs_status_code': status_code,
-        'exc_filename': exc_filename,
-        'exc_lineno': exc_lineno,
-        'exc_func': exc_func,
         'exc_first_arg': exc.args[0] if exc.args else None,
         'exc_detail': exc.detail if isinstance(exc, exceptions.APIException) else None
     }

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='django-rest-framework-simplify',
-    version='4.0.2.dev1',
+    version='4.0.3.dev1',
     description='Django Rest Framework Simplify',
     author='Skyler Cain',
     author_email='skylercain@gmail.com',

--- a/test_app/tests/test_handler.py
+++ b/test_app/tests/test_handler.py
@@ -7,6 +7,8 @@ from django.core.exceptions import PermissionDenied
 from rest_framework.test import APIClient
 from rest_framework import exceptions, status
 
+from rest_framework_simplify.exceptions import SimplifyAPIException
+
 
 @unittest.mock.patch('test_app.views.ThrowHandler.post')
 class ThrowHandlerTests(unittest.TestCase):
@@ -71,6 +73,18 @@ class ThrowHandlerTests(unittest.TestCase):
         # assert
         self.assertEqual(res.status_code, FooException.status_code)
         self.assertEqual(res.data['errorMessage'], FooException.default_detail)
+
+    def test_simplify_api_exception(self, mock_post):
+        # arrange
+        m = 'gud error'
+        mock_post.side_effect = SimplifyAPIException(m, status.HTTP_418_IM_A_TEAPOT)
+
+        # act
+        res = self.api_client.post('/throws')
+
+        # assert
+        self.assertEqual(res.status_code, status.HTTP_418_IM_A_TEAPOT)
+        self.assertEqual(res.data['errorMessage'], m)
 
     def test_exceptions_log(self, mock_post):
         # arrange

--- a/test_app/tests/test_handler.py
+++ b/test_app/tests/test_handler.py
@@ -1,0 +1,96 @@
+import logging
+import unittest
+import unittest.mock
+
+from django.http import Http404
+from django.core.exceptions import PermissionDenied
+from rest_framework.test import APIClient
+from rest_framework import exceptions, status
+
+
+@unittest.mock.patch('test_app.views.ThrowHandler.post')
+class ThrowHandlerTests(unittest.TestCase):
+
+    def setUp(self):
+        self.api_client = APIClient()
+
+    def test_basic_exception(self, mock_post):
+        # arrange
+        mock_post.side_effect = Exception('random exception')
+
+        # act
+        res = self.api_client.post('/throws')
+
+        # assert
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.data['errorMessage'], exceptions.APIException.default_detail)
+
+    def test_coerce_django_404(self, mock_post):
+        # arrange
+        mock_post.side_effect = Http404('custom message')
+
+        # act
+        res = self.api_client.post('/throws')
+
+        # assert
+        self.assertEqual(res.status_code, exceptions.NotFound.status_code)
+        self.assertEqual(res.data['errorMessage'], exceptions.NotFound.default_detail)
+
+    def test_coerce_django_permission_denied(self, mock_post):
+        # arrange
+        mock_post.side_effect = PermissionDenied('custom message')
+
+        # act
+        res = self.api_client.post('/throws')
+
+        # assert
+        self.assertEqual(res.status_code, exceptions.PermissionDenied.status_code)
+        self.assertEqual(res.data['errorMessage'], exceptions.PermissionDenied.default_detail)
+
+    def test_permission_denied_error_message(self, mock_post):
+        # arrange
+        mock_post.side_effect = exceptions.PermissionDenied('custom message')
+
+        # act
+        res = self.api_client.post('/throws')
+
+        # assert
+        self.assertEqual(res.status_code, exceptions.PermissionDenied.status_code)
+        self.assertEqual(res.data['errorMessage'], exceptions.PermissionDenied.default_detail)
+
+    def test_custom_exception(self, mock_post):
+        # arrange
+        class FooException(exceptions.APIException):
+            status_code = status.HTTP_418_IM_A_TEAPOT
+            default_detail = 'FooException occurred'
+        mock_post.side_effect = FooException()
+
+        # act
+        res = self.api_client.post('/throws')
+
+        # assert
+        self.assertEqual(res.status_code, FooException.status_code)
+        self.assertEqual(res.data['errorMessage'], FooException.default_detail)
+
+    def test_exceptions_log(self, mock_post):
+        # arrange
+        arg = 'custom message'
+        mock_exc = exceptions.ValidationError(arg)
+        mock_post.side_effect = mock_exc
+        logger = logging.getLogger('rest-framework-simplify-exception')
+        with unittest.mock.patch.object(logger, 'exception') as mock_log:
+            # act
+            res = self.api_client.post('/throws?foo=bar', {'baz': 'qux'})
+
+            # assert
+            self.assertTrue(mock_log.called)
+            error_message = mock_log.call_args[0][0]
+            extra = mock_log.call_args[1]['extra']
+            self.assertEqual(error_message, mock_exc.default_detail)
+            self.assertEqual(extra['rq_query_params']['foo'], 'bar')
+            self.assertEqual(extra['rq_data']['baz'], 'qux')
+            self.assertEqual(extra['rq_method'], 'POST')
+            self.assertEqual(extra['rq_path'], '/throws')
+            self.assertEqual(extra['rs_status_code'], res.status_code)
+            self.assertEqual(extra['exc_first_arg'], arg)
+            self.assertEqual(extra['exc_detail'], mock_exc.detail)

--- a/test_app/tests/test_views.py
+++ b/test_app/tests/test_views.py
@@ -145,7 +145,7 @@ class PerformCreateTests(unittest.TestCase):
         res = self.api_client.post(url, body, format='json')
 
         # assert
-        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
         self.assertFalse(BasicClass.objects.filter(name=name).exists())
 
     def test_post_transforms(self):
@@ -181,8 +181,7 @@ class PerformCreateTests(unittest.TestCase):
         res = self.api_client.post(url, body, format='json')
 
         # assert
-        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(res.data['errorMessage'], 'gud error')
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
         bc.refresh_from_db()
         self.assertIsNone(bc.child_one)
 
@@ -223,7 +222,7 @@ class PerformUpdateTests(unittest.TestCase):
         res = self.api_client.put(url, body, format='json')
 
         # assert
-        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(BasicClass.objects.get(id=bc.id).name, 'gud name')
 
     def test_put_transforms(self):
@@ -261,10 +260,6 @@ class GetQuerysetTests(unittest.TestCase):
 
         # assert
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            res.data['errorMessage'],
-            ErrorMessages.DOES_NOT_EXIST.format(BasicClass.__name__, bc.id)
-        )
 
     @patch(
         'test_app.views.ModelWithParentResourceHandler.get_queryset',
@@ -281,10 +276,6 @@ class GetQuerysetTests(unittest.TestCase):
 
         # assert
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            res.data['errorMessage'],
-            ErrorMessages.DOES_NOT_EXIST.format(ModelWithParentResource.__name__, c.id)
-        )
 
     @patch(
         'test_app.views.ChildClassHandler.get_queryset',
@@ -790,7 +781,6 @@ class ReadReplicaTests(unittest.TestCase):
 
         # assert
         self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(result.data['errorMessage'], ErrorMessages.DOES_NOT_EXIST.format(BasicClass.__name__, basic_class.id))
 
     def test_get_should_return_value_in_read_db_not_write_db(self):
         # arrange
@@ -862,7 +852,7 @@ class StoredProcedureTests(unittest.TestCase):
 
         # assert
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(res.data['errorMessage'], 'invalid user')
+        self.assertEqual(res.data['errorMessage'], ValidationError.default_detail)
 
     @unittest.skipUnless(
         settings.DATABASES['default']['ENGINE'] == 'django.db.backends.postgresql',
@@ -970,8 +960,6 @@ class EmailTemplateTests(unittest.TestCase):
 
         # assert
         self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(result.data['errorMessage'],
-                         SimplifyEmailTemplateView.ErrorMessages.INVALID_PARAMS.format(body['templateName']))
 
     def test_send_email_400_if_cant_find_html_file(self):
         # arrange
@@ -986,8 +974,6 @@ class EmailTemplateTests(unittest.TestCase):
 
         # assert
         self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(result.data['errorMessage'],
-                         SimplifyEmailTemplateView.ErrorMessages.MISSING_EMAIL_TEMPLATE_PATH.format(body['templateName']))
 
     def test_send_email_400_if_rdml_still_in_html(self):
         # arrange
@@ -1003,8 +989,6 @@ class EmailTemplateTests(unittest.TestCase):
 
         # assert
         self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(result.data['errorMessage'],
-                         SimplifyEmailTemplateView.ErrorMessages.UNABLE_TO_POPULATE_TEMPLATE.format(body['templateName'], 'Extra-Simplifyml'))
 
     @unittest.mock.patch('test_app.email_templates.EmailService.send_email')
     def test_send_email_400_if_send_email_fails(self, mock_send_email):
@@ -1024,7 +1008,6 @@ class EmailTemplateTests(unittest.TestCase):
 
         # assert
         self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(result.data['errorMessage'], SimplifyEmailTemplateView.ErrorMessages.ERROR_SENDING_EMAIL)
 
     def test_send_email_400_if_missing_send_email_method(self):
         # arrange
@@ -1040,7 +1023,6 @@ class EmailTemplateTests(unittest.TestCase):
 
         # assert
         self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(result.data['errorMessage'], SimplifyEmailTemplateView.ErrorMessages.MISSING_SEND_EMAIL_METHOD)
 
     def test_send_email_200_happy_path(self):
         # arrange
@@ -1078,7 +1060,7 @@ class EmailTemplateTests(unittest.TestCase):
 
         # assert
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(res.data['errorMessage'], 'unable to validate')
+        self.assertEqual(res.data['errorMessage'], ValidationError.default_detail)
 
     def test_send_email_clean_transforms(self):
         # arrange

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -150,3 +150,8 @@ class ModelWithParentResourceHandler(SimplifyView):
             supported_methods=['GET_SUB', 'GET_LIST_SUB'],
             linked_objects=linked_objects
         )
+
+
+class ThrowHandler(SimplifyView):
+    def __init__(self):
+        super().__init__(None, supported_methods=['POST'])

--- a/test_proj/settings.py
+++ b/test_proj/settings.py
@@ -71,6 +71,9 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'test_proj.wsgi.application'
 
+REST_FRAMEWORK = {
+    'EXCEPTION_HANDLER': 'rest_framework_simplify.handler.exception_handler'
+}
 
 # Database
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases

--- a/test_proj/urls.py
+++ b/test_proj/urls.py
@@ -3,7 +3,7 @@ from django.urls import re_path
 from test_app.views import BasicClassHandler, ChildClassHandler, LinkingClassHandler, \
     LinkingClassWithNoLinkingClsDefinedHandler, MetaDataClassHandler, ReadReplicaBasicClassHandler, \
     SqlStoredProcedureHandler, PostgresStoredProcedureHandler, SecondDatabaseBasicClassHandler, SendEmailHandler, \
-    OneToOneHandler, RequestFieldSaveHandler, PhaseGroupHandler, ModelWithParentResourceHandler
+    OneToOneHandler, RequestFieldSaveHandler, PhaseGroupHandler, ModelWithParentResourceHandler, ThrowHandler
 
 urlpatterns = [
     re_path(r'^(?P<parent_resource>[a-zA-z]+)/(?P<parent_pk>[0-9]+)/childOne$', ChildClassHandler.as_view()),
@@ -29,6 +29,7 @@ urlpatterns = [
     re_path(r'^secondDatabaseBasicClass$', SecondDatabaseBasicClassHandler.as_view()),
     re_path(r'^sendEmail$', SendEmailHandler.as_view()),
     re_path(r'^sqlStoredProcedures$', SqlStoredProcedureHandler.as_view()),
+    re_path(r'^throws$', ThrowHandler.as_view()),
     re_path(r'^postgresStoredProcedures$', PostgresStoredProcedureHandler.as_view()),
     re_path(r'^phaseGroups$', PhaseGroupHandler.as_view())
 ]


### PR DESCRIPTION
## Motivation
The purpose of this PR is to reduce the amount of information being returned from exceptions to a level deemed secure. I believe Simplify apps have been falling short on this due to two things.

The first thing being the `handle_exception` override in the `views.py` only covers the views defined in `views.py`. This means parts of an application that are using other views extending `APIView` will be using the rest framework `EXCEPTION_HANDLER` which does not likely lead to consistent behavior across an API.

The second thing being extracting the error message from `exc.args[0]`. This pattern makes it hard to be intentional about what information we are sharing with API consumers.

## Changes
These changes are inspired by Rest Frameworks guidelines on exception handling found here: https://www.django-rest-framework.org/api-guide/exceptions

This PR removes the `handle_exception` override from views throughout Simplify. This benefits us in that the code was duplicated across views which isn't necessarily a bad thing, but was causing diversion  between the implementations and extra noise. By defining our exception handler through the `REST_FRAMEWORK` settings we ensure consistent behavior, adhere closer to Rest Framework standards, compartmentalize the exception handler, and allow consumers of this library to use their own exception handler if desired.

In the exception handler itself we continue to use 400 status codes and the `errorMessage` key in the JSON response due to historical reasons and because these aren't important things to take on.

Includes the `_django_to_rest_framework` conversion inspired by the default rest framework handler `rest_framework.views.exception_handler`. I believe this is just a nice feature to include otherwise we would fall through to the default errors on these exceptions.

Removes the conversion of `NotAuthenticated` and `AuthenticationFailed` to 403. There is code in the calling `handle_exception` that does a similar thing, but it is not identical. The difference has to do with keeping the status code as a 401 given there is a WWW-Authenticate header otherwise performing the conversion to 403. I'll have to do more research to understand this, but I would like to make this change as it removes what I see as duplicated or ambiguous work.

Exposes `status_code` and `default_detail` as the response given an exception is or extends an `APIException`. This is closer to Rest Frameworks standards for exceptions. Note `detail` is preferred in the default exception handler, but we have determined these errors are too revealing for our purposes. One example being the `ValidationError` that is often raised when validating a serializer as this exception contains rich information about a fields requirements to make a request successful.

Due to our heavy handed approach to hiding error details in responses this PR also focuses on ensuring the exception handlers logging is as good as it can be. Some enhancements around this include switching to `logger.exception` in order to get stack traces (removes the need for traceback), including the old `exc.args[0]`, and including the `exc.detail`.