### PR TITLE
Audit error responses

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='django-rest-framework-simplify',
-    version='4.0.3.dev1',
+    version='4.0.4.dev1',
     description='Django Rest Framework Simplify',
     author='Skyler Cain',
     author_email='skylercain@gmail.com',

--- a/test_app/tests/test_views.py
+++ b/test_app/tests/test_views.py
@@ -12,9 +12,7 @@ from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
 from decimal import Decimal
-from rest_framework_simplify.errors import ErrorMessages
 from rest_framework_simplify.helpers import generate_str
-from rest_framework_simplify.views import SimplifyStoredProcedureView, SimplifyEmailTemplateView
 from rest_framework import status
 from rest_framework.test import APIClient
 from rest_framework.exceptions import PermissionDenied, ValidationError
@@ -616,8 +614,6 @@ class BasicClassTests(unittest.TestCase):
 
         # assert
         self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(result.data['errorMessage'], ErrorMessages.POST_SUB_WITH_ID_AND_NO_LINKING_CLASS.
-                         format(ChildClass.__name__))
 
     def test_get_with_bool_filter_of_true(self):
         # arrange
@@ -890,8 +886,6 @@ class StoredProcedureTests(unittest.TestCase):
 
         # assert
         self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(result.data['errorMessage'],
-                         SimplifyStoredProcedureView.ErrorMessages.INVALID_STORED_PROCEDURE.format(body['spName']))
 
     def test_post_without_param_returns_invalid_params_error(self):
         # arrange
@@ -905,8 +899,6 @@ class StoredProcedureTests(unittest.TestCase):
 
         # assert
         self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(result.data['errorMessage'],
-                         SimplifyStoredProcedureView.ErrorMessages.INVALID_PARAMS.format(body['spName']))
 
     @unittest.mock.patch('rest_framework_simplify.services.sql_executor.service.PostgresExecutorService.call_stored_procedure')
     def test_postgres(self, mock_execute_stored_procedure):
@@ -943,8 +935,6 @@ class EmailTemplateTests(unittest.TestCase):
 
         # assert
         self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(result.data['errorMessage'],
-                         SimplifyEmailTemplateView.ErrorMessages.INVALID_EMAIL_TEMPLATE.format(body['templateName']))
 
     def test_send_email_400_if_invalid_params(self):
         # arrange


### PR DESCRIPTION
## Summary
This PR examines usages of `Response` with error status codes. Where the error message may reveal too much information about the service. This means I found and replaced instances of `Response` and `self.create_response` where a error response would be returned with a method that goes through the exception handler.

## Reasons
In my opinion this PR has low impact and low risk. I might even be convinced it doesn't need to be done at all. However, I've thought of a few things to think about that could be beneficial.

We will now return the generic response "A server error occurred." for all of these cases. This is what we are trying to accomplish with our error handling improvements. I believe it falls under the OWASP guideline "Respond with generic error messages - avoid revealing details of the failure unnecessarily".

Because we are now going through the error handler, we are now logging all of these error responses. This will give us rich information about the exception, with the tradeoff we will now have to look this information up in our logging service.

We are writing slightly more intentional code in my opinion. For these reasons:
- We are no longer prone to dumb mistakes like the response body having `error_message` vs. `errorMessage`.
- We are writing slightly less verbose code to return an error response. Notice shorter line lenghts, dropping the kwarg, not needing the status code, and not needing to define the body. Notice the inconsistencies in the old way.
- Raising an exception allows us to abstract code as deep as we want while still maintaining fine grained control of the error response. 
- We are now sending exceptions to what ever exception handler the application has defined. This is more in the spirit of what Django has provided. With swappable exception handlers and a specific path for all exceptions to go through.
