### PR TITLE
[RP-17846] Updated code to handle weird dates and stringify them when using dates in forms

### DIFF
--- a/rest_framework_simplify/forms.py
+++ b/rest_framework_simplify/forms.py
@@ -66,6 +66,9 @@ class StoredProcedureForm(forms.Form):
     def _handle_adding_field_name(self, params, field_name):
         # todo this could cause issues with someone wanting to pass in an empty string as a param
         if self.cleaned_data[field_name] != '':
+            if isinstance(self.cleaned_data[field_name], datetime.date):
+                params.append(str(self.cleaned_data[field_name]))
+                return
             params.append(self.cleaned_data[field_name])
         else:
             params.append(None)

--- a/rest_framework_simplify/forms.py
+++ b/rest_framework_simplify/forms.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 import requests
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='django-rest-framework-simplify',
-    version='4.0.6.dev1',
+    version='4.0.7.dev1',
     description='Django Rest Framework Simplify',
     author='Skyler Cain',
     author_email='skylercain@gmail.com',

--- a/test_app/tests/test_views.py
+++ b/test_app/tests/test_views.py
@@ -8,7 +8,6 @@ import uuid
 os.environ['DJANGO_SETTINGS_MODULE'] = 'test_proj.settings'
 django.setup()
 
-from django import forms
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
@@ -864,10 +863,8 @@ class StoredProcedureTests(unittest.TestCase):
             'var_int': 1
         }
         def clean_mock(self):
-            # Call parent clean to ensure cleaned_data is properly set up
-            cleaned_data = forms.Form.clean(self)
-            cleaned_data['var_int'] = 2
-            return cleaned_data
+            self.cleaned_data['var_int'] = 2
+            return self.cleaned_data
 
         # act
         with patch('test_app.forms.PostgresFormatForm.clean', new=clean_mock):
@@ -1066,10 +1063,8 @@ class EmailTemplateTests(unittest.TestCase):
             'signUpUrl': 'https://mywebsite.com/signup?token=LLK69FkQ12'
         }
         def mock_clean(self):
-            # Call parent clean to ensure cleaned_data is properly set up
-            cleaned_data = forms.Form.clean(self)
-            cleaned_data['to'] = 'wrong' if self.request.user.is_superuser else 'transformed@example.com'
-            return cleaned_data
+            self.cleaned_data['to'] = 'wrong' if self.request.user.is_superuser else 'transformed@example.com'
+            return self.cleaned_data
 
         # act
         with patch('test_app.email_templates.DynamicEmailTemplate.clean', new=mock_clean):
@@ -1153,4 +1148,3 @@ class FilterablePropertiesTests(unittest.TestCase):
         # assert
         self.assertEqual(result.status_code, status.HTTP_200_OK)
         self.assertEqual(len(result.data), 1)
-

--- a/test_app/tests/test_views.py
+++ b/test_app/tests/test_views.py
@@ -8,6 +8,7 @@ import uuid
 os.environ['DJANGO_SETTINGS_MODULE'] = 'test_proj.settings'
 django.setup()
 
+from django import forms
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
@@ -863,8 +864,10 @@ class StoredProcedureTests(unittest.TestCase):
             'var_int': 1
         }
         def clean_mock(self):
-            self.cleaned_data['var_int'] = 2
-            return self.cleaned_data
+            # Call parent clean to ensure cleaned_data is properly set up
+            cleaned_data = forms.Form.clean(self)
+            cleaned_data['var_int'] = 2
+            return cleaned_data
 
         # act
         with patch('test_app.forms.PostgresFormatForm.clean', new=clean_mock):
@@ -1063,8 +1066,10 @@ class EmailTemplateTests(unittest.TestCase):
             'signUpUrl': 'https://mywebsite.com/signup?token=LLK69FkQ12'
         }
         def mock_clean(self):
-            self.cleaned_data['to'] = 'wrong' if self.request.user.is_superuser else 'transformed@example.com'
-            return self.cleaned_data
+            # Call parent clean to ensure cleaned_data is properly set up
+            cleaned_data = forms.Form.clean(self)
+            cleaned_data['to'] = 'wrong' if self.request.user.is_superuser else 'transformed@example.com'
+            return cleaned_data
 
         # act
         with patch('test_app.email_templates.DynamicEmailTemplate.clean', new=mock_clean):
@@ -1148,3 +1153,4 @@ class FilterablePropertiesTests(unittest.TestCase):
         # assert
         self.assertEqual(result.status_code, status.HTTP_200_OK)
         self.assertEqual(len(result.data), 1)
+


### PR DESCRIPTION
After updating to prepared SQL statements, we noticed some problems with dates, went ahead and updated the code to check if a field `isinstance` of datetime.date and if it is, we convert to a string.

Before:
<img width="1751" height="1101" alt="Screenshot 2025-10-01 at 11 16 50 AM" src="https://github.com/user-attachments/assets/e7dd1558-b2cf-44c7-8ebd-f108b1dac648" />

<img width="746" height="587" alt="Screenshot 2025-10-01 at 11 17 06 AM" src="https://github.com/user-attachments/assets/8adcbe01-c484-4371-8ac7-a794ed3a46e3" />

you can see the `TypeError` in the console

After:
<img width="1745" height="1050" alt="Screenshot 2025-10-06 at 3 27 17 PM" src="https://github.com/user-attachments/assets/52ca7faa-e232-470f-8397-b2fe348b98df" />

<img width="1753" height="1054" alt="Screenshot 2025-10-06 at 3 27 49 PM" src="https://github.com/user-attachments/assets/1cb43c87-496d-4449-8485-0a9526df51ac" />
