### PR TITLE
Ensure the name of the package is PEP 625 compliant

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,9 +84,9 @@ jobs:
       - deploy:
           name: PyPi Deploy
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              pip install --upgrade pip
+            if [ "${CIRCLE_BRANCH}" == "name_of_dist_pep_625" ]; then
+              pip install --upgrade pip build
               pip install twine
-              python setup.py sdist
-              twine upload --username __token__ --password "${PYPI_API_TOKEN}" dist/*
+              python -m build
+              ls -alh dist/
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,9 +84,9 @@ jobs:
       - deploy:
           name: PyPi Deploy
           command: |
-            if [ "${CIRCLE_BRANCH}" == "name_of_dist_pep_625" ]; then
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
               pip install --upgrade pip build
               pip install twine
               python -m build
-              ls -alh dist/
+              twine upload --username __token__ --password "${PYPI_API_TOKEN}" dist/*
             fi

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='django-rest-framework-simplify',
-    version='4.0.7.dev1',
+    version='4.0.8.dev1',
     description='Django Rest Framework Simplify',
     author='Skyler Cain',
     author_email='skylercain@gmail.com',


### PR DESCRIPTION
## Description
@Skylude received an email from the PyPI administrators stating that the name of this package does not conform with PEP 625.

### Email

---
This email is notifying you of an upcoming deprecation that we have determined may affect you as a result of your recent upload to 'django-rest-framework-simplify'.

In the future, PyPI will require all newly uploaded source distribution filenames to comply with PEP 625. Any source distributions already uploaded will remain in place as-is and do not need to be updated.

Specifically, your recent upload of 'django-rest-framework-simplify-4.0.7.dev1.tar.gz' is incompatible with PEP 625 because the filename does not contain the normalized project name 'django_rest_framework_simplify'.

In most cases, this can be resolved by upgrading the version of your build tooling to a later version that supports PEP 625 and produces compliant filenames. You do not need to remove the file.

If you have questions, you can email admin@pypi.org to communicate with the PyPI admin@pypi.org to communicate with the PyPI administrators.

---

### Solution
One simple solution is to ensure we have the latest `setuptools` package before invoking the `python setup.py sdist` command to build the distribution so that hyphens are replaced with underscores (see details below). However, this is not the solution I implemented. Instead, the solution in this PR takes it a little further and uses the `python -m build` command, which generates both a tar and a wheel file.

### Related PR
 * https://github.com/Skylude/django-rest-framework-signature/pull/38

### Resources
 * https://packaging.python.org/en/latest/specifications/binary-distribution-format/#binary-distribution-format
 * https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode

### Verification
To verify the change, I modified CircleCI's config.yaml file so that it would build it with this change and list the contents of the dist folder. Take note of the underscore's now instead of the hyphens that it used to be.

<img width="1185" height="569" alt="Screenshot 2025-11-03 at 3 37 45 PM" src="https://github.com/user-attachments/assets/47918aa7-b2c8-4f9b-98b3-2e845c5442d5" />

### Alternate solution
We could also upgrade the `setuptools` package to a newer version and it will build a PEP 625 compatible package. However, this will not create the `.whl` file. So this is also a viable solution. I chose not to implement this solution since the other way is the newer way.

